### PR TITLE
Removes `bio` field from users model

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,5 @@ made.
 -   [edvm](https://github.com/edvm)
 
 From before the fork, the entire [Cookiecutter-Django team](https://github.com/pydanny/cookiecutter-django).
+
+|Emiliano Dalla Verde Marcozzi|[\@edvm](https://github.com/edvm)|

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
@@ -9,7 +9,6 @@ class User(AbstractUser):
     # First Name and Last Name do not cover name patterns
     # around the globe.
     name = models.CharField(_("Name of User"), blank=True, max_length=255)
-    bio = models.TextField("Bio", blank=True)
 
     def get_absolute_url(self):
         return reverse("users:detail", kwargs={"username": self.username})


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
I just remove `bio` field from `users` models. Two reasons to do that:

1- Maybe who is going to use this template doesn't want users to have a `bio`

2- There isn't a migration script for that field, so the application fails when trying to create (signup) an user.



## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


