### PR TITLE
Add coverage for UserUpdateView form_valid method

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,7 +13,10 @@ These contributors have commit flags for the repository, and are able to accept 
 
 ## Other Code Contributors
 
+- [Modasser Billah](https://github.com/modasserbillah)
+
 Is this you?
+
 
 ## Issue Contributors
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -1,5 +1,8 @@
 import pytest
 from django.test import RequestFactory
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.views import UserRedirectView, UserUpdateView
@@ -33,6 +36,21 @@ class TestUserUpdateView:
         view.request = request
 
         assert view.get_object() == user
+
+    def test_form_valid(self, user: User, request_factory: RequestFactory):
+        form_data = {"name": "John Doe"}
+        request = request_factory.post(reverse("users:update"), form_data)
+        request.user = user
+        session_middleware = SessionMiddleware()
+        session_middleware.process_request(request)
+        msg_middleware = MessageMiddleware()
+        msg_middleware.process_request(request)
+
+        response = UserUpdateView.as_view()(request)
+        user.refresh_from_db()
+
+        assert response.status_code == 302
+        assert user.name == form_data["name"]
 
 
 class TestUserRedirectView:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -30,9 +30,9 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
         return User.objects.get(username=self.request.user.username)
 
     def form_valid(self, form):
-        messages.add_message(  # pragma: no cover
+        messages.add_message(
             self.request, messages.INFO, _("Infos successfully updated")
-        )  # pragma: no cover
+        )
         return super().form_valid(form)
 
 


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

This PR solves Issue#1. `form_valid` method in `UserUpdateView` was missing coverage.

RequestFactory only creates a request. But the form_valid() method adds a message. So, we need to set the middleware accordingly to simulate the update method of the view properly.

## Rationale

[//]: # (Why does the project need that?)
This raises the coverage to 100% again as promised. 



## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
Proof of coverage from running coverage report locally:
![image](https://user-images.githubusercontent.com/8477090/74332891-00764800-4dc1-11ea-83ce-4759104b0a0c.png)


