### PR TITLE
cookiecutter error relating to jinja variable solved

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ These individuals report issues that were closed after code changes were
 made.
 
 -   [edvm](https://github.com/edvm)
+-   [bmcneill](https://github.com/bfmcneill)
 
 From before the fork, the entire [Cookiecutter-Django team](https://github.com/pydanny/cookiecutter-django).
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,4 +1,4 @@
-{{cookiecutter.project\_name}}
+{{cookiecutter.project_name}}
 ==============================
 
 {{cookiecutter.description}}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

I am following along with the new Django Crash Book (loving it so far!!) and tried to do the cookiecutter but for some reason I kept getting an error from the README.md line 1.  I removed the backslash on the jinja variable and now the cookiecutter works.  


## Rationale

[//]: # (Why does the project need that?)
It seems the cookiecutter does not work without the change.  
![issue](https://user-images.githubusercontent.com/16538715/75943650-d5789480-5e52-11ea-99b4-e4577c97be55.PNG)





## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


