### PR TITLE
Use gettext_lazy instead of ugettext_lazy

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model, forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 User = get_user_model()
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class User(AbstractUser):


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

- Use `gettext_lazy` instead of `ugettext_lazy` because `ugettext_lazy` has marked as deprecated.


## Rationale

[//]: # (Why does the project need that?)

- Since the default string encoding in Python3 is a Unicode (In the old Python2.7 the default string encoding was ASCII) and after Django 2.0, the Django codebase is Python3 only, the `ugettext_lazy` function has been deprecated in Django 2.0 in favor of `gettext_lazy`.
The  `ugettext_lazy` function will be completely removed from the Django code base on the future Django 4.0 release.
