### PR TITLE
Revert mypy version to 0.761

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -7,7 +7,8 @@ psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy==0.770  # https://github.com/python/mypy
+mypy==0.761, <0.770 # https://github.com/python/mypy
+# mypy >0.760 and <0.770 is required by django-stubs==1.4.0
 django-stubs==1.4.0  # https://github.com/typeddjango/django-stubs
 pytest==5.3.5  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

- Revert `mypy` version from 0.770 to 0.761


## Rationale

[//]: # (Why does the project need that?)

The `django-stubs==1.4.0` require the `mypy` version between >0.760 and <0.770 .


